### PR TITLE
Fix .aar build

### DIFF
--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -18,6 +18,11 @@ android {
         }
     }
 
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**.aar** is not generated in JitPack repo

JitPack output:
[Before](https://jitpack.io/com/github/solkin/disk-lru-cache/v1.7/build.log):
```
✅ Build artifacts:
com.github.solkin:disk-lru-cache:v1.7

Files: 
com/github/solkin/disk-lru-cache/v1.7
com/github/solkin/disk-lru-cache/v1.7/build.log
com/github/solkin/disk-lru-cache/v1.7/disk-lru-cache-v1.7-sources.jar
com/github/solkin/disk-lru-cache/v1.7/disk-lru-cache-v1.7.pom
com/github/solkin/disk-lru-cache/v1.7/disk-lru-cache-v1.7.pom.md5
com/github/solkin/disk-lru-cache/v1.7/disk-lru-cache-v1.7.pom.sha1
```

[After](https://jitpack.io/com/github/khoben/disk-lru-cache/v1.7.1/build.log):
```
✅ Build artifacts:
com.github.khoben:disk-lru-cache:v1.7.1

Files: 
com/github/khoben/disk-lru-cache/v1.7.1
com/github/khoben/disk-lru-cache/v1.7.1/build.log
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1-sources.jar
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1.aar
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1.module
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1.pom
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1.pom.md5
com/github/khoben/disk-lru-cache/v1.7.1/disk-lru-cache-v1.7.1.pom.sha1
```